### PR TITLE
feat(db): Add basic library management API

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -1,0 +1,40 @@
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+import models
+import schemas
+
+
+def get_books(db: Session, author_id: int | None = None, skip: int = 0, limit: int = 100) -> list:
+    query = db.query(models.Book)
+    if author_id is not None:
+        query = query.filter(models.Book.author_id == author_id)
+    return query.offset(skip).limit(limit).all()
+
+
+def create_book(db: Session, book: schemas.BookCreate) -> models.Book:
+    book = models.Book(**book.dict())
+    db.add(book)
+    db.commit()
+    db.refresh(book)
+    return book
+
+
+def get_all_author(db: Session, skip: int = 0, limit: int = 100) -> list:
+    return db.query(models.Author).offset(skip).limit(limit).all()
+
+
+def create_author(db: Session, author: schemas.AuthorCreate) -> models.Author:
+    author = models.Author(**author.dict())
+    db.add(author)
+    db.commit()
+    db.refresh(author)
+    return author
+
+
+def retrieve_author(db: Session, author_id: int) -> models.Author:
+    author = db.query(models.Author).filter(models.Author.id == author_id).first()
+    if not author:
+        raise HTTPException(status_code=404, detail="Author not found")
+    return author
+

--- a/database.py
+++ b/database.py
@@ -1,0 +1,12 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./library-manager.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,47 @@
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+import crud
+import schemas
+from database import SessionLocal
+
+app = FastAPI()
+
+
+def get_db() -> Session:
+    db = SessionLocal()
+
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.get("/authors/", response_model=list[schemas.AuthorSchema])
+def get_authors(db: Session = Depends(get_db)):
+    return crud.get_all_author(db=db, skip=0, limit=5)
+
+
+@app.get("/authors/{author_id}/", response_model=schemas.AuthorSchema)
+def get_author(author_id: int, db: Session = Depends(get_db)):
+    return crud.retrieve_author(db=db, author_id=author_id)
+
+
+@app.post("/authors/", response_model=schemas.AuthorSchema)
+def create_author(author: schemas.AuthorCreate, db: Session = Depends(get_db)):
+    return crud.create_author(db=db, author=author)
+
+
+@app.get("/books/", response_model=list[schemas.BookSchema])
+def get_books(db: Session = Depends(get_db)):
+    return crud.get_books(db=db, skip=0, limit=5)
+
+
+@app.get("/books/{author_id}", response_model=list[schemas.BookSchema])
+def get_book(author_id: int, db: Session = Depends(get_db)):
+    return crud.get_books(db=db, skip=0, limit=5, author_id=author_id)
+
+
+@app.post("/books/", response_model=schemas.BookSchema)
+def create_book(book: schemas.BookCreate, db: Session = Depends(get_db)):
+    return crud.create_book(db=db, book=book)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, Date
+from sqlalchemy.orm import relationship
+
+from database import Base
+
+
+class Author(Base):
+    __tablename__ = 'Author'
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False, unique=True)
+    bio = Column(String(255), nullable=False)
+
+
+class Book(Base):
+    __tablename__ = 'Book'
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(100), nullable=False)
+    summary = Column(String(255), nullable=False)
+    publication_date = Column(Date, nullable=False)
+    author_id = Column(Integer, ForeignKey("Author.id"))
+    author = relationship("Author")

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,37 @@
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class AuthorBase(BaseModel):
+    name: str
+    bio: str
+
+
+class AuthorCreate(AuthorBase):
+    pass
+
+
+class AuthorSchema(AuthorBase):  # Renamed to avoid conflict
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class BookBase(BaseModel):
+    title: str
+    summary: str
+    publication_date: date
+
+
+class BookCreate(BookBase):
+    author_id: int
+
+
+class BookSchema(BookBase):  # Renamed to avoid conflict
+    id: int
+    author: AuthorSchema
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
Implement basic CRUD operations for authors and books using FastAPI, SQLAlchemy, and an SQLite database.  Includes models, schemas, CRUD functions, and API endpoints.